### PR TITLE
Handle the case when the partition is not provided

### DIFF
--- a/eto/fluent/datasets.py
+++ b/eto/fluent/datasets.py
@@ -100,7 +100,10 @@ def to_eto(
     df = spark.createDataFrame(self, schema)
     sdk_conf = Config.load()
     path = os.path.join(sdk_conf["tmp_workspace_path"], str(uuid.uuid4()))
-    df.write.format("rikai").mode(mode).partitionBy(partition).save(path)
+    writer = df.write.format("rikai").mode(mode)
+    if partition:
+        writer = writer.partitionBy(partition)
+    writer.save(path)
     job = ingest_rikai(dataset_name, path, mode, partition)
     if wait:
         return job


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/lei/work/sophon/tools/./create_index.py", line 68, in <module>
    import_cifar()
  File "/home/lei/work/sophon/tools/./create_index.py", line 44, in import_cifar
    df.to_eto("cifar10", mode="overwrite")
  File "/home/lei/miniconda3/envs/mining/lib/python3.10/site-packages/eto/util.py", line 55, in wrapper
    return func(self, *args, **kwargs)
  File "/home/lei/miniconda3/envs/mining/lib/python3.10/site-packages/eto/fluent/datasets.py", line 103, in to_eto
    df.write.format("rikai").mode(mode).partitionBy(partition).save(path)
  File "/home/lei/miniconda3/envs/mining/lib/python3.10/site-packages/pyspark/sql/readwriter.py", line 1109, in save
    self._jwrite.save(path)
  File "/home/lei/miniconda3/envs/mining/lib/python3.10/site-packages/py4j/java_gateway.py", line 1304, in __call__
    return_value = get_return_value(
  File "/home/lei/miniconda3/envs/mining/lib/python3.10/site-packages/pyspark/sql/utils.py", line 117, in deco
    raise converted from None
pyspark.sql.utils.AnalysisException: Partition column `null` not found in schema struct<split:string,image:struct<data:binary,uri:string>,label:string,label_id:bigint>
```